### PR TITLE
Mc message scroll bar

### DIFF
--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -16,13 +16,11 @@ export const Nutshell = () => {
 </header>
 <section class="formArea"></section>
 <section class="homePage">
-    <article class="section messages">
-        <h2>messages</h2>
+    <article class="section messages">        
+        <h2 id="message-header">messages</h2>
         <div class="messages__display">
-            <p>first message here</p>
         </div>
         <div class="messages__form"></div>
-        
     </article>
     <article class="section events">
         <h2>events</h2>

--- a/src/scripts/message/MessageForm.js
+++ b/src/scripts/message/MessageForm.js
@@ -16,7 +16,7 @@ export const messageForm = () => {
 // But will change if the user clicks on the edit button
 const render = (text) => {
     const contentTarget = document.querySelector(".messages__form")
-    contentTarget.innerHTML = `<input type="text" id="messages__form" value="${text.message}">
+    contentTarget.innerHTML = `<input type="text" placeholder="Type new post" id="messages__form" value="${text.message}">
     <button id="messages__save"> post</button>
     <input type="hidden" name="${text.id}" id="messageId">`
 }

--- a/src/scripts/message/MessageList.js
+++ b/src/scripts/message/MessageList.js
@@ -18,8 +18,8 @@ export const messageList=()=>{
 const render=(messages,users)=>{
     // get the content target
     const contentTarget=document.querySelector(".messages__display")
-// go through all the messages
-    const messagesHTML=messages.map(individualMessage=> {
+// go through all the messages. Use the reverse method so that the newest message always displays on the bottom instead of the top.
+    const messagesHTML=messages.reverse().map(individualMessage=> {
         // for each message, find the matching user
         const relatedUser=users.find(user=>user.id===individualMessage.userId)
         // put the matching user and the message into the html creator in the message.js module

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -24,3 +24,21 @@ h1{
 .section > h2{
     text-align: center;
 }
+
+.section {
+    height: 350px;
+    overflow: scroll;
+    overflow-x: hidden;
+}
+.messages__display {
+    display: flex;
+    flex-direction: column-reverse;
+    height: 260px;
+    overflow: scroll;
+    overflow-x: hidden;
+}
+
+.messages {
+    overflow: hidden
+}
+


### PR DESCRIPTION
# Description
The messages scroll bar should start at the bottom, and should also have the most recent message displaying at the bottom
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
git checkout master
git fetch --all
git checkout mc-messageScrollBar
serve

log in as a user, make sure you have enough messages to generate the scroll bar. Once there is a scroll bar, refresh the page and verify
A) that the scroll bar starts at the bottom, and
B) that the newest message is displayed at the bottom.

After these steps have been completed, please congratulate me on my impressive work, regardless of the fact that all main functionality was suggested to me by outside sources and are not my original idea.

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings or errors
- [ x] I have added test instructions that prove my fix is effective or that my feature works
