### PR TITLE
private message scroll bar

### DIFF
--- a/src/scripts/message/PrivateChatList.js
+++ b/src/scripts/message/PrivateChatList.js
@@ -16,8 +16,7 @@ eventHub.addEventListener("privateChatStarted",e=>{
 
 export const privateMessageList=()=>{
     const contentTarget=document.querySelector(".friends")
-    contentTarget.innerHTML=`<article class="section privateMessage">
-    <h2>Private Chat</h2>
+    contentTarget.innerHTML=` <h2>Private Chat</h2> <article class="section privateMessage">
     <button id="backToFriends"> Back to Friends </button>
     <div class="privateMessage__form"></div>
     <div class="privateMessage__display"></div>

--- a/src/scripts/message/PrivateChatList.js
+++ b/src/scripts/message/PrivateChatList.js
@@ -18,9 +18,9 @@ export const privateMessageList=()=>{
     const contentTarget=document.querySelector(".friends")
     contentTarget.innerHTML=`<article class="section privateMessage">
     <h2>Private Chat</h2>
-    <div class="privateMessage__display"></div>
-    <div class="privateMessage__form"></div>
     <button id="backToFriends"> Back to Friends </button>
+    <div class="privateMessage__form"></div>
+    <div class="privateMessage__display"></div>
     </article>`
 
     const user=parseInt(sessionStorage.getItem("activeUser"))

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -174,3 +174,8 @@ section {
 strong{
     color: #c49b60;
 }
+
+.privateMessage {
+    display: flex;
+    flex-direction: column-reverse;
+}


### PR DESCRIPTION
# Description
set it so that private messages start from the  bottom, including the scroll bar
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
git checkout master
git fetch --all
git checkout mc-privateMessageScrollBar

serve
check the private messages, make sure you have enough messages to necessitate a scroll bar, then refresh, and ensure that the scroll bar starts at the bottom, along with the latest message/form/back to friends button

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings or errors
- [x ] I have added test instructions that prove my fix is effective or that my feature works
